### PR TITLE
add critical section and rt dependencies and feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,10 @@ categories = ["embedded", "hardware-support", "no-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+critical-section = { version = "1.0", optional = true }
+riscv-rt = { version = "0.11.0", optional = true }
+riscv = "0.10.1"
 vcell = "0.1.3"
+
+[features]
+rt = ["riscv-rt"]


### PR DESCRIPTION
This is necessary so that crate consumers can use `Peripherals::take()`.
see https://docs.rs/svd2rust/latest/svd2rust/#other-targets

Signed-off-by: Daniel Maslowski <info@orangecms.org>
